### PR TITLE
Expose io

### DIFF
--- a/Example/TensorIO/TensorIO-Info.plist
+++ b/Example/TensorIO/TensorIO-Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Example/Tests/TensorIOTFLiteModelIntegrationTests.mm
+++ b/Example/Tests/TensorIOTFLiteModelIntegrationTests.mm
@@ -73,6 +73,11 @@
     XCTAssertNotNil(bundle);
     XCTAssertNotNil(model);
     
+    // Ensure inputs and outputs return correct count
+    
+    XCTAssert(model.inputs.count == 1);
+    XCTAssert(model.outputs.count == 1);
+    
     // Run the model on a number
     
     NSNumber *numericInput = @(2);
@@ -108,6 +113,13 @@
     XCTAssertNotNil(bundle);
     XCTAssertNotNil(model);
     
+    // Ensure inputs and outputs return correct count
+    
+    XCTAssert(model.inputs.count == 1);
+    XCTAssert(model.outputs.count == 1);
+    
+    // Expected output
+    
     TIOVector *expectedZ = @[@(2),@(2),@(4),@(4)];
     
     // Run the model on a vector
@@ -134,6 +146,13 @@
     
     XCTAssertNotNil(bundle);
     XCTAssertNotNil(model);
+    
+    // Ensure inputs and outputs return correct count
+    
+    XCTAssert(model.inputs.count == 2);
+    XCTAssert(model.outputs.count == 2);
+    
+    // Run model on number
     
     NSArray *vectorInputs = @[
         @[@1,  @2,  @3,  @4],
@@ -168,6 +187,13 @@
     XCTAssertNotNil(bundle);
     XCTAssertNotNil(model);
     
+    // Ensure inputs and outputs return correct count
+    
+    XCTAssert(model.inputs.count == 2);
+    XCTAssert(model.outputs.count == 2);
+    
+    // Expected outputs
+    
     TIOVector *expectedS = @[
         @(18),   @(18),   @(18),   @(18),
         @(180),  @(180),  @(180),  @(180),
@@ -180,6 +206,8 @@
         @(560000),  @(720000),  @(560000),  @(720000),
         @(56000000),@(72000000),@(56000000),@(72000000)
     ];
+    
+    // Run model on numbers
     
     NSArray *matrixInput = @[
         @[
@@ -234,11 +262,20 @@
     XCTAssertNotNil(bundle);
     XCTAssertNotNil(model);
     
+    // Ensure inputs and outputs return correct count
+    
+    XCTAssert(model.inputs.count == 1);
+    XCTAssert(model.outputs.count == 1);
+    
+    // Expected outputs
+    
     TIOVector *expectedZ = @[
         @(2),  @(3),  @(4),  @(5),  @(6),  @(7),  @(8),  @(9),  @(10),
         @(12), @(22), @(32), @(42), @(52), @(62), @(72), @(82), @(92),
         @(103),@(203),@(303),@(403),@(503),@(603),@(703),@(803),@(903)
     ];
+    
+    // Run model on numbers
     
     TIOVector *vectorInput = @[
         @(1),  @(2),  @(3),  @(4),  @(5),  @(6),  @(7),  @(8),  @(9),
@@ -250,6 +287,8 @@
     
     XCTAssert(vectorResults.count == 1);
     XCTAssert([vectorResults[@"output_z"] isEqualToArray:expectedZ]);
+    
+    // Run model on bytes
     
     float_t byteInput[27] = {
         1,  2,  3,  4,  5,  6,  7,  8,  9,
@@ -272,11 +311,16 @@
     TIOModelBundle *bundle = [self bundleWithName:@"1_in_1_out_pixelbuffer_identity_test.tfbundle"];
     id<TIOModel> model = [self loadModelFromBundle:bundle];
     
+    // Ensure inputs and outputs return correct count
+    
+    XCTAssert(model.inputs.count == 1);
+    XCTAssert(model.outputs.count == 1);
+    
+    // Create ARGB bytes
+    
     const int width = 224;
     const int height = 224;
     const int channels = 4;
-    
-    // Create ARGB bytes
     
     uint8_t *bytes = (uint8_t *)malloc(224*224*4*sizeof(uint8_t));
     
@@ -354,11 +398,16 @@
     TIOModelBundle *bundle = [self bundleWithName:@"1_in_1_out_pixelbuffer_normalization_test.tfbundle"];
     id<TIOModel> model = [self loadModelFromBundle:bundle];
     
+    // Ensure inputs and outputs return correct count
+    
+    XCTAssert(model.inputs.count == 1);
+    XCTAssert(model.outputs.count == 1);
+    
+    // Create ARGB bytes
+    
     const int width = 224;
     const int height = 224;
     const int channels = 4;
-    
-    // Create ARGB bytes
     
     uint8_t *bytes = (uint8_t *)malloc(224*224*4*sizeof(uint8_t));
     
@@ -440,6 +489,13 @@
     XCTAssertNotNil(bundle);
     XCTAssertNotNil(model);
     
+    // Ensure inputs and outputs return correct count
+    
+    XCTAssert(model.inputs.count == 1);
+    XCTAssert(model.outputs.count == 1);
+    
+    // Prepare image input
+    
     UIImage *image = [UIImage imageNamed:@"example-image"];
     TIOPixelBuffer *imageFeature = [[TIOPixelBuffer alloc] initWithPixelBuffer:image.pixelBuffer orientation:kCGImagePropertyOrientationUp];
     
@@ -474,6 +530,13 @@
     
     XCTAssertNotNil(bundle);
     XCTAssertNotNil(model);
+    
+    // Ensure inputs and outputs return correct count
+    
+    XCTAssert(model.inputs.count == 1);
+    XCTAssert(model.outputs.count == 1);
+    
+    // Prepare image input
     
     UIImage *image = [UIImage imageNamed:@"example-image"];
     TIOPixelBufferLayerDescription *description = (TIOPixelBufferLayerDescription*)[model descriptionOfInputAtIndex:0];
@@ -512,6 +575,13 @@
     
     XCTAssertNotNil(bundle);
     XCTAssertNotNil(model);
+    
+    // Ensure inputs and outputs return correct count
+    
+    XCTAssert(model.inputs.count == 1);
+    XCTAssert(model.outputs.count == 1);
+    
+    // Prepare image input
     
     UIImage *image = [UIImage imageNamed:@"example-image"];
     TIOPixelBuffer *imageFeature = [[TIOPixelBuffer alloc] initWithPixelBuffer:image.pixelBuffer orientation:kCGImagePropertyOrientationUp];

--- a/TensorIO.podspec
+++ b/TensorIO.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TensorIO'
-  s.version          = '0.3.0'
+  s.version          = '0.3.1'
   s.summary          = 'An Objective-C wrapper for TensorFlow Lite.'
   s.description      = 'Perform inference with TensorFlow Lite models using all the conveniences of Objective-C'
   s.homepage         = 'https://github.com/doc-ai/TensorIO'

--- a/TensorIO/Classes/TIO Model/TIOModel.h
+++ b/TensorIO/Classes/TIO Model/TIOModel.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol TIOData;
 @protocol TIOLayerDescription;
+@class TIOLayerInterface;
 @class TIOModelBundle;
 @class TIOModelOptions;
 
@@ -129,6 +130,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 
 @property (readonly) BOOL loaded;
+
+/**
+ * Returns descriptions of the model's inputs indexed to the order they appear in model.json.
+ */
+
+@property (readonly) NSArray<TIOLayerInterface*> *inputs;
+
+/**
+ * Returns descriptions of the model's outputs indexed to the order they appear in model.json.
+ */
+
+@property (readonly) NSArray<TIOLayerInterface*> *outputs;
 
 /**
  * The designated initializer for conforming classes.

--- a/TensorIO/Classes/TIO Model/TIOModel.h
+++ b/TensorIO/Classes/TIO Model/TIOModel.h
@@ -196,7 +196,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns a description of the model's input at a given index
  *
- * Model inputs and outputs are organized by index and name. In the model.json file that descrbies
+ * Model inputs and outputs are organized by index and name. In the model.json file that describes
  * the interface to a model, an array of named inputs includes information such as the type of
  * data the input expects, its volume, and any transformations that will be applied to it.
  *
@@ -210,7 +210,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns a description of the model's input for a given name
  *
- * Model inputs and outputs are organized by index and name. In the model.json file that descrbies
+ * Model inputs and outputs are organized by index and name. In the model.json file that describes
  * the interface to a model, an array of named inputs includes information such as the type of
  * data the input expects, its volume, and any transformations that will be applied to it.
  *
@@ -218,12 +218,13 @@ NS_ASSUME_NONNULL_BEGIN
  * inputs provided to the `runOn:` method prior to performing inference. See TIOModelBundleJSONSchema.h
  * for more information about this json file.
  */
+ 
 - (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name;
 
 /**
  * Returns a description of the model's output at a given index
  *
- * Model inputs and outputs are organized by index and name. In the model.json file that descrbies
+ * Model inputs and outputs are organized by index and name. In the model.json file that describes
  * the interface to a model, an array of named inputs includes information such as the type of
  * data the input expects, its volume, and any transformations that will be applied to it.
  *
@@ -237,7 +238,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns a description of the model's output for a given name
  *
- * Model inputs and outputs are organized by index and name. In the model.json file that descrbies
+ * Model inputs and outputs are organized by index and name. In the model.json file that describes
  * the interface to a model, an array of named inputs includes information such as the type of
  * data the input expects, its volume, and any transformations that will be applied to it.
  *

--- a/TensorIO/Classes/TIO TensorFlow Lite Model/TIOTFLiteModel.h
+++ b/TensorIO/Classes/TIO TensorFlow Lite Model/TIOTFLiteModel.h
@@ -29,7 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
  * An Objective-C wrapper around TensorFlow lite models that provides a unified interface to the
  * input and output layers of the underlying model.
  *
- * See `TIOModel` for more information about TensorIO models.
+ * See `TIOModel` for more information about TensorIO models and for a description of the
+ * conforming properties and methods here.
  */
 
 @interface TIOTFLiteModel : NSObject <TIOModel>

--- a/TensorIO/Classes/TIO TensorFlow Lite Model/TIOTFLiteModel.h
+++ b/TensorIO/Classes/TIO TensorFlow Lite Model/TIOTFLiteModel.h
@@ -50,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) NSString *type;
 @property (readonly) BOOL loaded;
 
+@property (readonly) NSArray<TIOLayerInterface*> *inputs;
+@property (readonly) NSArray<TIOLayerInterface*> *outputs;
+
 // Model Protocol Methods
 
 - (nullable instancetype)initWithBundle:(TIOModelBundle*)bundle NS_DESIGNATED_INITIALIZER;

--- a/TensorIO/Classes/TIO TensorFlow Lite Model/TIOTFLiteModel.mm
+++ b/TensorIO/Classes/TIO TensorFlow Lite Model/TIOTFLiteModel.mm
@@ -300,6 +300,14 @@ static NSString * const kTensorTypeImage = @"image";
 
 // MARK: - Input and Output Features
 
+- (NSArray<TIOLayerInterface*>*)inputs {
+    return _indexedInputInterfaces;
+}
+
+- (NSArray<TIOLayerInterface*>*)outputs {
+    return _indexedOutputInterfaces;
+}
+
 - (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index {
     return _indexedInputInterfaces[index].dataDescription;
 }


### PR DESCRIPTION
Publicly expose the description of the model's inputs and outputs, and test. This is required in order to build a labeling UI based on the description of the model's outputs.