### PR TITLE
add placeholder model and tests for it

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		DF4D5DC63A3A51A173FA808753699D05 /* UIImage+TIOCVPixelBufferExtensions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D420CC27E3A311E8832054E8B98AB7E /* UIImage+TIOCVPixelBufferExtensions.mm */; };
 		E32FB5DF2149CC0800367B11 /* TIOModelBundleValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = E32FB5DD2149CC0800367B11 /* TIOModelBundleValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E32FB5E02149CC0800367B11 /* TIOModelBundleValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = E32FB5DE2149CC0800367B11 /* TIOModelBundleValidator.m */; };
+		E344014121E924A600B6E9CC /* TIOPlaceholderModel.mm in Sources */ = {isa = PBXBuildFile; fileRef = E344013E21E9245D00B6E9CC /* TIOPlaceholderModel.mm */; };
+		E344014221E924AD00B6E9CC /* TIOPlaceholderModel.h in Headers */ = {isa = PBXBuildFile; fileRef = E344013D21E9245D00B6E9CC /* TIOPlaceholderModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E7B1A6475E134933EB482E4AEBAEDDEE /* NSDictionary+TIOData.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B4570021DC3C331403416F57DB24619 /* NSDictionary+TIOData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EF9E829E1021FC48C6BE990A8A46859C /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3315DA7D67E67293373873794FE04C74 /* VideoToolbox.framework */; };
 		EFDEC9485484C1653116E3CA97A35759 /* NSData+TIOData.mm in Sources */ = {isa = PBXBuildFile; fileRef = BEAAE2BFA02BE24C3AA1F487580E4F2F /* NSData+TIOData.mm */; };
@@ -173,6 +175,8 @@
 		E1719288A270235757DF95735F26F8D9 /* TIOVisionPipeline.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = TIOVisionPipeline.mm; sourceTree = "<group>"; };
 		E32FB5DD2149CC0800367B11 /* TIOModelBundleValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TIOModelBundleValidator.h; sourceTree = "<group>"; };
 		E32FB5DE2149CC0800367B11 /* TIOModelBundleValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TIOModelBundleValidator.m; sourceTree = "<group>"; };
+		E344013D21E9245D00B6E9CC /* TIOPlaceholderModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TIOPlaceholderModel.h; sourceTree = "<group>"; };
+		E344013E21E9245D00B6E9CC /* TIOPlaceholderModel.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TIOPlaceholderModel.mm; sourceTree = "<group>"; };
 		E45E4691AB2B6AE43E352379478EE64B /* Pods-TensorIO_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TensorIO_Example-resources.sh"; sourceTree = "<group>"; };
 		E6C72F557AB0C40BA79C5E8CD40023D3 /* TIOCVPixelBufferHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOCVPixelBufferHelpers.h; sourceTree = "<group>"; };
 		E82B320CF8BB8268AD84702361873CDB /* TIOVisionModelHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOVisionModelHelpers.h; sourceTree = "<group>"; };
@@ -291,6 +295,8 @@
 			isa = PBXGroup;
 			children = (
 				73BE0F74C7334D110B782D7C7A4E0DFC /* TIOModel.h */,
+				E344013D21E9245D00B6E9CC /* TIOPlaceholderModel.h */,
+				E344013E21E9245D00B6E9CC /* TIOPlaceholderModel.mm */,
 				CFC24433C0A45E38F0B4649F7182C4CE /* TIOModelBundle.h */,
 				288F5DB80F9E97CB674ECEB00CC07F2C /* TIOModelBundle.m */,
 				E32FB5DD2149CC0800367B11 /* TIOModelBundleValidator.h */,
@@ -486,6 +492,7 @@
 				545EDE019CE44C00572B0086139F41B6 /* TIOCVPixelBufferHelpers.h in Headers */,
 				D76984970AB5B0F6F271F3CE7327DA76 /* TIOData.h in Headers */,
 				A3F0BD9D17EB8964E71DC50183D47B2C /* TIOLayerDescription.h in Headers */,
+				E344014221E924AD00B6E9CC /* TIOPlaceholderModel.h in Headers */,
 				86EFDA26026B31BA7209F88C27155422 /* TIOLayerInterface.h in Headers */,
 				7F582188E2CCC327745920EAAF5DC652 /* TIOModel.h in Headers */,
 				3F73AC7CCB445FFB9F2E68F05854D9DB /* TIOModelBundle.h in Headers */,
@@ -621,6 +628,7 @@
 				4143E262C08E599467216A4A0ED19A7E /* NSDictionary+TIOExtensions.m in Sources */,
 				F5BFED1B23A022214065F640E118FD1B /* NSNumber+TIOData.mm in Sources */,
 				4C03110535890CABA70AB71BB5747619 /* TensorIO-dummy.m in Sources */,
+				E344014121E924A600B6E9CC /* TIOPlaceholderModel.mm in Sources */,
 				2F43E4D0B98979098DC29A8FB9ADD7DC /* TIOCVPixelBufferHelpers.mm in Sources */,
 				50D67B27B6E47234E408740CD1E7D7B2 /* TIOLayerInterface.mm in Sources */,
 				E32FB5E02149CC0800367B11 /* TIOModelBundleValidator.m in Sources */,

--- a/Example/Tests/TensorIOModelBundleValidatorTests.mm
+++ b/Example/Tests/TensorIOModelBundleValidatorTests.mm
@@ -2171,4 +2171,23 @@
     XCTAssertNil(error);
 }
 
+//MARK: - Placeholder Models
+
+- (void)testPlaceholderModelValidates {
+    TIOModelBundleValidator *validator;
+    NSError *error;
+    BOOL valid;
+    
+    // it should validate
+    
+    error = nil;
+    valid = NO;
+    
+    validator = [self validatorForFilename:@"placeholder.tfbundle"];
+    valid = [validator validate:&error];
+    
+    XCTAssertTrue(valid);
+    XCTAssertNil(error);
+}
+
 @end

--- a/Example/Tests/TensorIOTFLiteModelIntegrationTests.mm
+++ b/Example/Tests/TensorIOTFLiteModelIntegrationTests.mm
@@ -611,4 +611,16 @@
     }
 }
 
+// MARK: - Placeholder Model
+
+- (void)testPlaceholderModel {
+    TIOModelBundle *bundle = [self bundleWithName:@"placeholder.tfbundle"];
+    id<TIOModel> model = [self loadModelFromBundle:bundle];
+    
+    XCTAssertNotNil(bundle);
+    XCTAssertNotNil(model);
+    
+    XCTAssert([model isKindOfClass:TIOPlaceholderModel.class]);
+}
+
 @end

--- a/Example/models-tests/placeholder.tfbundle/model.json
+++ b/Example/models-tests/placeholder.tfbundle/model.json
@@ -1,0 +1,27 @@
+{
+	"name": "Placeholder model",
+	"details": "Bundle with no model file that should otherwise parse the json and instantiate an empty model.",
+	"id": "placeholder_test",
+	"version": "1",
+	"author": "doc.ai",
+	"license": "",
+	"placeholder": true,
+	"model": {
+		"file": null,
+		"quantized": false
+	},
+	"inputs": [
+		{
+			"name": "input_x",
+			"type": "array",
+			"shape": [1]
+		}
+	],
+	"outputs": [
+		{
+			"name": "output_z",
+			"type": "array",
+			"shape": [1]
+		}
+	]
+}

--- a/TensorIO/Classes/TIO Model/TIOModel.h
+++ b/TensorIO/Classes/TIO Model/TIOModel.h
@@ -109,6 +109,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) NSString* license;
 
 /**
+ * A boolean value indicating if this is a placeholder bundle.
+ *
+ * A placeholder bundle has no underlying model and instantiates a `TIOModel` that does nothing.
+ * Placeholders bundles are used to collect labeled data for models that haven't been trained yet.
+ */
+
+@property (readonly) BOOL placeholder;
+
+/**
  * A boolean value indicating if the model is quantized or not.
  *
  * Quantized models have 8 bit `uint8_t` interfaces while unquantized modesl have 32 bit, `float_t`

--- a/TensorIO/Classes/TIO Model/TIOModelBundle.h
+++ b/TensorIO/Classes/TIO Model/TIOModelBundle.h
@@ -116,7 +116,16 @@ extern NSString * const kTFModelAssetsDirectory;
 @property (readonly) NSString *license;
 
 /**
- * A boolean value indicated if the model represnted by this bundle is quantized or not.
+ * A boolean value indicating if this is a placeholder bundle.
+ *
+ * A placeholder bundle has no underlying model and instantiates a `TIOModel` that does nothing.
+ * Placeholders bundles are used to collect labeled data for models that haven't been trained yet.
+ */
+
+@property (readonly, getter=isPlaceholder) BOOL placeholder;
+
+/**
+ * A boolean value indicating if the model represnted by this bundle is quantized or not.
  */
 
 @property (readonly) BOOL quantized;
@@ -136,10 +145,11 @@ extern NSString * const kTFModelAssetsDirectory;
 /**
  * The file path to the actual underlying model contained in this bundle.
  *
- * Currently, only tflite models are supported.
+ * Currently, only tflite models are supported. If this `placeholder` is `YES` this property
+ * returns `nil`.
  */
 
-@property (readonly) NSString *modelFilepath;
+@property (nullable, readonly) NSString *modelFilepath;
 
 /**
  * Designated initializer.

--- a/TensorIO/Classes/TIO Model/TIOModelBundle.m
+++ b/TensorIO/Classes/TIO Model/TIOModelBundle.m
@@ -22,6 +22,7 @@
 
 #import "TIOModel.h"
 #import "TIOModelOptions.h"
+#import "TIOPlaceholderModel.h"
 
 NSString * const kTFModelBundleExtension = @"tfbundle";
 NSString * const kTFModelInfoFile = @"model.json";
@@ -82,12 +83,19 @@ NSString * const kTFModelAssetsDirectory = @"assets";
         _modelClassName = json[@"model"][@"class"] != nil
             ? json[@"model"][@"class"]
             : kTFLiteModelClassName;
+        
+        _placeholder = json[@"placeholder"] != nil
+                    && [json[@"placeholder"] boolValue] == YES;
     }
     
     return self;
 }
 
 - (nullable id<TIOModel>)newModel {
+    
+    if ( self.placeholder ) {
+        return [[TIOPlaceholderModel alloc] initWithBundle:self];
+    }
     
     Class ModelClass = NSClassFromString(self.modelClassName);
     
@@ -107,7 +115,11 @@ NSString * const kTFModelAssetsDirectory = @"assets";
 }
 
 - (NSString*)modelFilepath {
-    return [_path stringByAppendingPathComponent:_info[@"model"][@"file"]];
+    if (self.isPlaceholder) {
+        return nil;
+    } else {
+        return [_path stringByAppendingPathComponent:_info[@"model"][@"file"]];
+    }
 }
 
 - (NSString*)pathToAsset:(NSString*)filename {

--- a/TensorIO/Classes/TIO Model/TIOPlaceholderModel.h
+++ b/TensorIO/Classes/TIO Model/TIOPlaceholderModel.h
@@ -1,9 +1,9 @@
 //
-//  TIOTFLiteModel.h
+//  TIOPlaceholderModel.h
 //  TensorIO
 //
-//  Created by Philip Dow on 8/3/18.
-//  Copyright © 2018 doc.ai (http://doc.ai)
+//  Created by Philip Dow on 1/11/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
+
 #import <Foundation/Foundation.h>
 
 #import "TIOLayerInterface.h"
@@ -26,14 +27,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * An Objective-C wrapper around TensorFlow lite models that provides a unified interface to the
- * input and output layers of the underlying model.
- *
- * See `TIOModel` for more information about TensorIO models and for a description of the
- * conforming properties and methods here.
+ * A placeholder model declares an interface but does not contain any underlying model
+ * implementation. It is used to gather labeled data for a model that has not been trained
+ * yet. Performing inference with a placeholder model will return an empty result.
  */
 
-@interface TIOTFLiteModel : NSObject <TIOModel>
+@interface TIOPlaceholderModel : NSObject <TIOModel>
 
 + (nullable instancetype)modelWithBundleAtPath:(NSString*)path;
 

--- a/TensorIO/Classes/TIO Model/TIOPlaceholderModel.mm
+++ b/TensorIO/Classes/TIO Model/TIOPlaceholderModel.mm
@@ -1,0 +1,268 @@
+//
+//  TIOPlaceholderModel.m
+//  TensorIO
+//
+//  Created by Philip Dow on 1/11/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "TIOPlaceholderModel.h"
+
+#import "TIOLayerInterface.h"
+#import "TIOModelBundle.h"
+#import "TIOData.h"
+#import "TIOLayerInterface.h"
+#import "TIOLayerDescription.h"
+#import "TIOPixelBufferLayerDescription.h"
+#import "TIOVectorLayerDescription.h"
+#import "NSDictionary+TIOData.h"
+#import "TIOModelJSONParsing.h"
+
+static NSString * const kTensorTypeVector = @"array";
+static NSString * const kTensorTypeImage = @"image";
+
+@implementation TIOPlaceholderModel {
+    // Index to Interface Description
+    NSArray<TIOLayerInterface*> *_indexedInputInterfaces;
+    NSArray<TIOLayerInterface*> *_indexedOutputInterfaces;
+    
+    // Name to Interface Description
+    NSDictionary<NSString*,TIOLayerInterface*> *_namedInputInterfaces;
+    NSDictionary<NSString*,TIOLayerInterface*> *_namedOutputInterfaces;
+    
+    // Name to Index
+    NSDictionary<NSString*,NSNumber*> *_namedInputToIndex;
+    NSDictionary<NSString*,NSNumber*> *_namedOutputToIndex;
+}
+
++ (nullable instancetype)modelWithBundleAtPath:(NSString*)path {
+    return [[[TIOModelBundle alloc] initWithPath:path] newModel];
+}
+
+- (void)dealloc {
+    #ifdef DEBUG
+    NSLog(@"Deallocating model");
+    #endif
+}
+
+- (nullable instancetype)initWithBundle:(TIOModelBundle*)bundle {
+    if (self = [super init]) {
+        _bundle = bundle;
+        _options = bundle.options;
+        
+        _identifier = bundle.identifier;
+        _name = bundle.name;
+        _details = bundle.details;
+        _author = bundle.author;
+        _license = bundle.license;
+        _placeholder = bundle.placeholder;
+        _quantized = bundle.quantized;
+        _type = bundle.type;
+        
+        // Input and output parsing
+        
+        NSArray<NSDictionary<NSString*,id>*> *inputs = bundle.info[@"inputs"];
+        NSArray<NSDictionary<NSString*,id>*> *outputs = bundle.info[@"outputs"];
+        
+        if ( inputs == nil ) {
+            NSLog(@"Expected input array field in model.json, none found");
+            return nil;
+        }
+        
+        if ( outputs == nil ) {
+            NSLog(@"Expected output array field in model.json, none found");
+            return nil;
+        }
+        
+        if ( ![self _parseInputs:inputs] ) {
+            NSLog(@"Unable to parse input field in model.json");
+            return nil;
+        }
+        
+        if ( ![self _parseOutputs:outputs] ) {
+            NSLog(@"Unable to parse output field in model.json");
+            return nil;
+        }
+    }
+    
+    return self;
+}
+
+- (nullable instancetype)init {
+    self = [self initWithBundle:[[TIOModelBundle alloc] initWithPath:@""]];
+    NSAssert(NO, @"Use the designated initializer initWithBundle:");
+    return nil;
+}
+
+// MARK: - JSON Parsing
+
+// TODO: Move JSON Parsing to an external function or to the model bundle class
+
+/**
+ * Enumerates through the json described inputs and constructs a `TIOLayerInterface` for each one.
+ *
+ * @param inputs An array of dictionaries describing the model's input layers
+ *
+ * @return BOOL `YES` if the json descriptions were successfully parsed, `NO` otherwise
+ */
+
+- (BOOL)_parseInputs:(NSArray<NSDictionary<NSString*,id>*>*)inputs {
+    
+    auto *indexedInputInterfaces = [NSMutableArray<TIOLayerInterface*> array];
+    auto *namedInputInterfaces = [NSMutableDictionary<NSString*,TIOLayerInterface*> dictionary];
+    auto *namedInputToIndex = [NSMutableDictionary<NSString*,NSNumber*> dictionary];
+    
+    auto isQuantized = self.quantized;
+    auto isInput = YES;
+    
+    __block BOOL error = NO;
+    
+    [inputs enumerateObjectsUsingBlock:^(NSDictionary<NSString *,id> * _Nonnull input, NSUInteger idx, BOOL * _Nonnull stop) {
+        
+        NSString *type = input[@"type"];
+        NSString *name = input[@"name"];
+        
+        TIOLayerInterface *interface;
+        
+        if ( [type isEqualToString:kTensorTypeVector] ) {
+            interface = TIOTFLiteModelParseTIOVectorDescription(input, isInput, isQuantized, self->_bundle);
+        } else if ( [type isEqualToString:kTensorTypeImage] ) {
+            interface = TIOTFLiteModelParseTIOPixelBufferDescription(input, isInput, isQuantized);
+        }
+        
+        if ( interface == nil ) {
+            error = YES;
+            *stop = YES;
+            return;
+        }
+        
+        [indexedInputInterfaces addObject:interface];
+        namedInputInterfaces[name] = interface;
+        namedInputToIndex[name] = @(idx);
+    }];
+    
+    _indexedInputInterfaces = indexedInputInterfaces.copy;
+    _namedInputInterfaces = namedInputInterfaces.copy;
+    _namedInputToIndex = namedInputToIndex.copy;
+    
+    return !error;
+}
+
+/**
+ * Enumerates through the json described outputs and constructs a `TIOLayerInterface` for each one.
+ *
+ * @param outputs An array of dictionaries describing the model's output layers
+ *
+ * @return BOOL `YES` if the json descriptions were successfully parsed, `NO` otherwise
+ */
+
+- (BOOL)_parseOutputs:(NSArray<NSDictionary<NSString*,id>*>*)outputs {
+    
+    auto *indexedOutputInterfaces = [NSMutableArray<TIOLayerInterface*> array];
+    auto *namedOutputInterfaces = [NSMutableDictionary<NSString*,TIOLayerInterface*> dictionary];
+    auto *namedOutputToIndex = [NSMutableDictionary<NSString*,NSNumber*> dictionary];
+    
+    auto isQuantized = self.quantized;
+    auto isInput = NO;
+    
+    __block BOOL error = NO;
+    
+    [outputs enumerateObjectsUsingBlock:^(NSDictionary<NSString *,id> * _Nonnull output, NSUInteger idx, BOOL * _Nonnull stop) {
+    
+        NSString *type = output[@"type"];
+        NSString *name = output[@"name"];
+        
+        TIOLayerInterface *interface;
+        
+        if ( [type isEqualToString:kTensorTypeVector] ) {
+            interface = TIOTFLiteModelParseTIOVectorDescription(output, isInput, isQuantized, self->_bundle);
+        } else if ( [type isEqualToString:kTensorTypeImage] ) {
+            interface = TIOTFLiteModelParseTIOPixelBufferDescription(output, isInput, isQuantized);
+        }
+        
+        if ( interface == nil ) {
+            error = YES;
+            *stop = YES;
+            return;
+        }
+        
+        [indexedOutputInterfaces addObject:interface];
+        namedOutputInterfaces[name] = interface;
+        namedOutputToIndex[name] = @(idx);
+    }];
+    
+    _indexedOutputInterfaces = indexedOutputInterfaces.copy;
+    _namedOutputInterfaces = namedOutputInterfaces.copy;
+    _namedOutputToIndex = namedOutputToIndex.copy;
+    
+    return !error;
+}
+
+// MARK: - Model Memory Management
+
+/**
+ * Loads a model into memory and sets `loaded` = `YES`. A placeholder model does nothing here.
+ */
+
+- (BOOL)load:(NSError**)error {
+    _loaded = YES;
+    return YES;
+}
+
+/**
+ * Unloads the model and sets `loaded` =`NO`. A placeholder model doest nothing here.
+ */
+
+- (void)unload {
+    _loaded = NO;
+}
+
+// MARK: - Input and Output Features
+
+- (NSArray<TIOLayerInterface*>*)inputs {
+    return _indexedInputInterfaces;
+}
+
+- (NSArray<TIOLayerInterface*>*)outputs {
+    return _indexedOutputInterfaces;
+}
+
+- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index {
+    return _indexedInputInterfaces[index].dataDescription;
+}
+
+- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name {
+    return _namedInputInterfaces[name].dataDescription;
+}
+
+- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index {
+    return _indexedOutputInterfaces[index].dataDescription;
+}
+
+- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name {
+    return _namedOutputInterfaces[name].dataDescription;
+}
+
+// MARK: - Perform Inference
+
+/**
+ * A placeholder model performs no inference and returns an empty dictionary
+ */
+
+- (id<TIOData>)runOn:(id<TIOData>)input {
+    return @{};
+}
+
+@end

--- a/TensorIO/Classes/TIO TensorFlow Lite Model/TIOTFLiteModel.mm
+++ b/TensorIO/Classes/TIO TensorFlow Lite Model/TIOTFLiteModel.mm
@@ -80,6 +80,7 @@ static NSString * const kTensorTypeImage = @"image";
         _details = bundle.details;
         _author = bundle.author;
         _license = bundle.license;
+        _placeholder = bundle.placeholder;
         _quantized = bundle.quantized;
         _type = bundle.type;
         
@@ -119,6 +120,8 @@ static NSString * const kTensorTypeImage = @"image";
 }
 
 // MARK: - JSON Parsing
+
+// TODO: Move JSON Parsing to an external function or to the model bundle class
 
 /**
  * Enumerates through the json described inputs and constructs a `TIOLayerInterface` for each one.

--- a/TensorIO/Classes/TensorIO.h
+++ b/TensorIO/Classes/TensorIO.h
@@ -27,6 +27,7 @@
 #import "TIOModelJSONParsing.h"
 #import "TIOModelOptions.h"
 #import "TIOPixelNormalization.h"
+#import "TIOPlaceholderModel.h"
 #import "TIOQuantization.h"
 #import "TIOVisionModelHelpers.h"
 #import "TIOVisionPipeline.h"


### PR DESCRIPTION
Placeholder models are model bundles which contain the model.json description and valid descriptions of a model's input and output layers but which contain no underlying model. We will use them to collect label data for models that haven't been trained yet.