### PR TITLE
In prep for 1.1 update and updates to the example notebooks

### DIFF
--- a/examples/ios/Podfile
+++ b/examples/ios/Podfile
@@ -2,8 +2,8 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'TensorIOExamples' do
-  pod 'TensorIO/Core'
-  pod 'TensorIO/TensorFlow'
+  pod 'TensorIO/Core', '~> 1.0.0'
+  pod 'TensorIO/TensorFlow', '~> 1.0.0'
 
   target 'TensorIOExamplesTests' do
     # inherit! :search_paths

--- a/examples/ios/Podfile.lock
+++ b/examples/ios/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
-  - TensorIO/Core (0.9.7):
+  - TensorIO/Core (1.0.1):
     - DSJSONSchemaValidation
-  - TensorIO/TensorFlow (0.9.7):
+  - TensorIO/TensorFlow (1.0.1):
     - DSJSONSchemaValidation
     - TensorIO/Core
-    - TensorIOTensorFlow
-  - TensorIOTensorFlow (1.13.5)
+    - TensorIOTensorFlow (~> 1.13.0)
+  - TensorIOTensorFlow (1.13.6)
 
 DEPENDENCIES:
-  - TensorIO/Core
-  - TensorIO/TensorFlow
+  - TensorIO/Core (~> 1.0.0)
+  - TensorIO/TensorFlow (~> 1.0.0)
 
 SPEC REPOS:
   trunk:
@@ -20,9 +20,9 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
-  TensorIO: 428a8b90ee4a14622a6be6eced43e1eb04b6cdf7
-  TensorIOTensorFlow: 66391fb72910e7814aec5c0ab1d4789a81ac3399
+  TensorIO: 1cd798d391b0c6ee85bf9d1d2e153308722dd976
+  TensorIOTensorFlow: 9da41ecb33073d226c592fe945a63437b973685a
 
-PODFILE CHECKSUM: 93046af6d343e8b1821e8fa45a930761032d7ce5
+PODFILE CHECKSUM: ab33d3b6327c49157029d55267fa31f48d63f07f
 
-COCOAPODS: 1.9.0
+COCOAPODS: 1.9.1

--- a/examples/ios/download_models.sh
+++ b/examples/ios/download_models.sh
@@ -4,7 +4,7 @@
 ## Downloads models from our public tensorio-examples bucket
 ## 
 
-MODELS_URL=https://storage.googleapis.com/tensorio-examples/models.tar.gz
+MODELS_URL=https://storage.googleapis.com/tensorio-examples/r1.13/models.tar.gz
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORK_DIR=`mktemp -d`


### PR DESCRIPTION
Let's make sure we have a commit on master that locks the ios examples to the right version of tensorflow, tensor/io, and the examples.