### PR TITLE
use total_loss in test

### DIFF
--- a/examples/ios/TensorIOExamplesTests/TF_2_0_KerasCIFAR10MobileNetTests.swift
+++ b/examples/ios/TensorIOExamplesTests/TF_2_0_KerasCIFAR10MobileNetTests.swift
@@ -139,7 +139,7 @@ class TF_2_0_KerasCIFAR10MobileNetTests: XCTestCase {
             XCTAssertNotNil(output)
             XCTAssertNil(error)
             
-            let loss = (output as! NSDictionary)["sparse_categorical_crossentropy/weighted_loss/value"] as? Float
+            let loss = (output as! NSDictionary)["total_loss"] as? Float
             
             XCTAssertNotNil(loss)
         }


### PR DESCRIPTION
following up on the other pr where i export a network that is fully trainable rather than just the last layer.